### PR TITLE
NOx contamination correction

### DIFF
--- a/neonNTrans/DESCRIPTION
+++ b/neonNTrans/DESCRIPTION
@@ -2,8 +2,8 @@ Package: neonNTrans
 Type: Package
 Date: 2017-12-01
 Title: NEON Nitrogen Transformations
-Version: 0.2.0
-Author: person("Samantha", "Weintraub", email = "sweintraub@battelleecology.org", 
+Version: 0.3.0
+Author: person("Samantha", "Weintraub-Leff", email = "sweintraub@battelleecology.org", 
     role = c("aut", "cre"))
 Description: Contains a function to calculate soil inorganic nitrogen 
     concentrations from potassium chloride extracts as well as net nitrogen

--- a/neonNTrans/DESCRIPTION
+++ b/neonNTrans/DESCRIPTION
@@ -15,4 +15,4 @@ Depends:
 License: AGPL-3 + file LICENSE
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.1
+RoxygenNote: 7.2.3

--- a/neonNTrans/R/def.calc.ntrans.R
+++ b/neonNTrans/R/def.calc.ntrans.R
@@ -67,7 +67,9 @@
 
 #' @references
 #' License: GNU AFFERO GENERAL PUBLIC LICENSE Version 3, 19 November 2007
+#' 
 #' Homyak, P.M., Vasquez, K.T., Sickman, J.O., Parker, D.R. and Schimel, J.P. (2015). Improving Nitrite Analysis in Soils: Drawbacks of the Conventional 2 M KCl Extraction. Soil Science Society of America Journal, 79: 1237‐1242. doi:10.2136/sssaj2015.02.0061n
+#' 
 #' Weintraub-Leff, S.R., Hall, S.J., Craig, M.E., Sihi, D., Wang, Z. and Hart, S.C. (2023). Standardized data to improve understanding and modeling of soil nitrogen at continental scale. Earth's Future, 11, e2022EF003224. doi.org/10.1029/2022EF003224
 
 #' @keywords soil, nitrogen, mineralization, nitrification

--- a/neonNTrans/R/def.calc.ntrans.R
+++ b/neonNTrans/R/def.calc.ntrans.R
@@ -1,44 +1,58 @@
 ################################################################################
 #' @title NEON Soil Inorganic N Concentrations and Net N Transformation Rates
 
-#' @author Samantha Weintraub \email{sweintraub@battelleecology.org}
+#' @author Samantha Weintraub-Leff \email{sweintraub@battelleecology.org}
 
 #' @description Calculate soil extractable inorganic nitrogen concentrations and
 #' net N transformation rates for NEON L1 data. Recommend using the
 #' neonUtilities package to download data from DP1.10086.001 prior to running this function. 
 #' Function requires several data product tables as inputs in order to complete calculations.
-#' 
+
 #' @details The function calculates blank-corrected concentration data using the mean of all blanks
-#' extracted with a batch of samples, then normalizes these per gram dry soil (and per day for rates).
-#' Any negative blank-corrected KCl extraction data are set to 0 before proceeding with 
-#' further transformations. This is robust for slightly negative values near method detection limits (0.01-0.02). However, 
-#' highly negative values (< -0.02) may indicate an issue. Extensive troubleshooting by NEON suggests this was prevalent 
-#' in samples collected prior to 2020 due to high nitrite in the KCl powder used for extractions. This nitrite was 
-#' chemodenitrified (removed as a gas) under the acidic conditions of samples but not blanks, e.g., the very 
-#' negative values are most often a contamination artifact. Instead of setting these highly negative values to 0, we recommend 
-#' excluding them altogether, since there may have been N in the sample but it was not detectable given method artifacts.
-#' Values with blank-corrected values < -0.02 are flagged by NEON, thus users can easily exclude them using the following arguments
-#' in the function: dropAmmoniumFlags = "blanks exceed sample value", dropNitrateFlags = "blanks exceed sample value". 
-#' If these arguments are not used, all negative values will be converted to 0 and included in the analyses.
+#' extracted with a batch of samples, then normalizes these per gram dry soil (and per day for net rates). 
+#' 
+#' Data from certain sites collected prior to 2022 exhibit frequent blank-corrected nitrate + nitrite 
+#' concentrations significantly negative beyond background noise (< -0.02). This was caused by inadvertently 
+#' using batches of potassium chloride (KCl) for soil extractions with high nitrite contamination. Nitrite is 
+#' chemodenitrified, or abiotically converted to nitrogen gas and lost, in the presence of acidic soil 
+#' but not in blanks (Homyak et al. 2015), which causes this artifact. It is possible to correct the affected 
+#' data using a quantile regression, essentially 'adding back' the lost nitrite and removing apparent 
+#' negatives (Weintraub-Leff at al. 2023). This correction is applied by the function to all data collected 
+#' in 2021 and earlier, unless users select noxCorrection = F. Starting with the 2022 sampling season and 
+#' onward, all batches of KCl are purity tested before use, greatly reducing (although not eliminating) 
+#' the occurrence of blank-corrected sample concentration values < -0.02. 
+#' 
+#' After applying the noxCorrection (for pre-2022 data), any remaining negative 
+#' blank-corrected concentration values are set to 0 by the function before proceeding with 
+#' further data transformations. Concentration values that blank-correct to < -0.02 are flagged by NEON
+#' in the ntr_externalLab table, thus if users would rather exclude these data points instead of using
+#' the noxCorrection and/or assigning them to zero, they should specify function parameters 
+#' dropAmmoniumFlags or dropNitrateFlags = "blanks exceed sample value". 
 
 #' @param kclInt A data frame containing soil masses and kcl volumes used in KCl
 #'   extractions. Data product table name is ntr_internalLab
 #' @param kclIntBlank A data frame containing information needed to link KCl
 #'   extraction samples to procedural blanks. Data product table name is
 #'   ntr_internalLabBlanks
-#' @param kclExt A data frame containing inorganic N concentrations measured in
+#' @param kclExt A data frame containing inorganic N concentrations measured in sample
 #'   KCl extractions and blanks. Data product table name is ntr_externalLab
 #' @param soilMoist A data frame containing soil moisture values. Data product
 #'   table name is sls_soilMoisture
+#' @param noxCorrection A parameter that specifies whether the quantile regression
+#'   approach outlined in Weintraub-Leff et al (2023) should be used to correct for 
+#'   contaminant nitrite in 2021 and earlier data, defaults to T
 #' @param dropConditions An optional list of sampleCondition or dataQF values for which to exclude
-#'   ammonium and nitrate N concentration measurements (set them to NA). See categorical codes file 
-#'   and data product user guide for more on these fields.
+#'   ammonium and nitrate + nitrite N concentration measurements (set them to NA). 
+#'   See categorical codes file and data product user guide for more on these fields.
 #' @param dropAmmoniumFlags An optional list of ammoniumNQF values for which to exclude
 #'   ammonium N concentration measurements (set them to NA). See categorical codes file 
 #'   and data product user guide for more on these fields.
 #' @param dropNitrateFlags An optional list of nitrateNitriteNQF values for which to exclude
 #'   nitrate+nitrite N concentration measurements (set them to NA). See categorical codes file 
-#'   and data product user guide for more on these fields.
+#'   and data product user guide for more on these fields. If 'blanks exceed sample value'
+#'   is selected along with the default noxCorrection = T, values are only dropped if
+#'   they still blank-correct negative after the correction is applied (relevant 
+#'   to pre-2022 data).
 
 #' @return A list that contains at least 2 data frames, and up to 5 depending on specified parameters. 
 #' all_data is a combined dataframe of external and internal lab measurements,
@@ -46,14 +60,15 @@
 #' incubated samples. data_summary is a cleaned-up version of this information showing only
 #' calculated variables and excluding lab metadata. Users will likely wish to use this table for downstream
 #' analyses and can join on sampleID to link with other NEON soil measurements. dropped_condition is 
-#' a dataframe that shows which samples had values set to NA due to dropCondition inputs (if applicable). dropped_flags
-#' is a dataframe that shows which samples had values set to NA due to dropAmmoniumFlags and/or
-#' dropNitrateFlags inputs (if applicable). dropped_moisture is a dataframe that shows which samples are
-#' missing soil moisture, thus precluding downstream calculations.
-
+#' a dataframe that shows which samples had values set to NA due to dropCondition inputs (if applicable). 
+#' dropped_flags is a dataframe that shows which samples had values set to NA due to dropAmmoniumFlags 
+#' and/or dropNitrateFlags inputs (if applicable). dropped_moisture is a dataframe that shows which samples 
+#' are missing soil moisture (if), thus precluding downstream calculations.
 
 #' @references
 #' License: GNU AFFERO GENERAL PUBLIC LICENSE Version 3, 19 November 2007
+#' Homyak, P.M., Vasquez, K.T., Sickman, J.O., Parker, D.R. and Schimel, J.P. (2015). Improving Nitrite Analysis in Soils: Drawbacks of the Conventional 2 M KCl Extraction. Soil Science Society of America Journal, 79: 1237‐1242. doi:10.2136/sssaj2015.02.0061n
+#' Weintraub-Leff, S.R., Hall, S.J., Craig, M.E., Sihi, D., Wang, Z. and Hart, S.C. (2023). Standardized data to improve understanding and modeling of soil nitrogen at continental scale. Earth's Future, 11, e2022EF003224. doi.org/10.1029/2022EF003224
 
 #' @keywords soil, nitrogen, mineralization, nitrification
 
@@ -72,8 +87,8 @@
 #' kclIntBlank = soilData$ntr_internalLabBlanks, 
 #' kclExt = soilData$ntr_externalLab, 
 #' soilMoist = soilData$sls_soilMoisture, 
-#' dropAmmoniumFlags = "blanks exceed sample value", 
-#' dropNitrateFlags = "blanks exceed sample value" 
+#' dropConditions = c("extract stored at incorrect temperature", "soil stored at incorrect temperature", 
+#' "mass uncertain", "volume uncertain") 
 #' )
 #' 
 #' # If data are downloaded to a computer, then need to be loaded manually
@@ -88,7 +103,8 @@
 #' kclIntBlank = df2, 
 #' kclExt =df3, 
 #' soilMoist = df4,
-#' dropConditions = c("deprecatedMethod", "other"), 
+#' noxCorrection = F, 
+#' dropNitrateFlags = "blanks exceed sample value" 
 #' )
 #' }
 
@@ -107,6 +123,9 @@
 #     new parameters to allow for more detailed filtering based on external lab QF fields,
 #     deal with KCl extraction analytical replicates by taking mean,
 #     change format of output from single dataframe to list with several tables.
+#   Samantha Weintraub-Leff (2023-12-07)
+#     new parameter to implement the quantile regression approach to correct for 
+#     contaminant nitrite in 2021 and earlier data
 ################################################################################
 
 # Function
@@ -114,20 +133,21 @@ def.calc.ntrans <- function(kclInt,
                             kclIntBlank,
                             kclExt,
                             soilMoist,
+                            noxCorrection = T,
                             dropConditions,
                             dropAmmoniumFlags,
                             dropNitrateFlags
 ) {
   
   
-  # check for missing datasets
+  # Check for missing datasets ----
   null.check = sapply(list(kclInt, kclIntBlank, kclExt, soilMoist), is.null)
   nullDSs = c('kclInt', 'kclIntBlank', 'kclExt', 'soilMoist')[null.check]
   if (length(nullDSs) > 0) {
     stop(paste0(paste(nullDSs, collapse = ', '), ' dataset(s) missing.'))
   }
   
-  # take means of analytical reps, KCl extraction data
+  # Take means of analytical reps, KCl extraction data ----
   kclExt <- kclExt %>%
     group_by(kclSampleID) %>%
     summarise_all(list( ~ if (is.numeric(.)) {
@@ -136,7 +156,7 @@ def.calc.ntrans <- function(kclInt,
       first(.)
     }))
   
-  # join the internal and external lab data
+  # Join the internal and external lab data ----
   suppressWarnings(suppressMessages(combinedDF <-
                                       left_join(
                                         kclExt,
@@ -155,7 +175,7 @@ def.calc.ntrans <- function(kclInt,
                                         suffix = c(".externalLab", ".internalLab")
                                       )))
   
-  # set data values to NA based on sample condition or dataQF values (optional)
+  # Set data values to NA based on sample condition or dataQF values (optional) ----
   if(!missing(dropConditions)) {
     # conditions and NEON quality flags in external lab data
     combinedDF$kclAmmoniumNConc[combinedDF$sampleCondition.externalLab %in% dropConditions] <- NA
@@ -211,7 +231,7 @@ def.calc.ntrans <- function(kclInt,
         paste(
           'Note:',
           num2,
-          'records had concentration values set to NA due to dataQF values reported by the external lab',
+          'records had concentration values set to NA due to dataQF values reported in external lab data',
           sep = " "
         )
       print(warning2)
@@ -225,7 +245,7 @@ def.calc.ntrans <- function(kclInt,
         paste(
           'Note:',
           num2a,
-          'records had concentration values set to NA due to dataQF values reported during NEON lab processing',
+          'records had concentration values set to NA due to dataQF values reported in NEON lab data',
           sep = " "
         )
       print(warning2a)
@@ -234,11 +254,11 @@ def.calc.ntrans <- function(kclInt,
     }
   }
   
-  # set concentration data to NA based on ammonium or nitrate quality flags (optional)
+  # Set concentration data to NA based on ammonium quality flags (optional) ----
   if(!missing(dropAmmoniumFlags)) {
     combinedDF$kclAmmoniumNConc[combinedDF$ammoniumNQF %in% dropAmmoniumFlags] <- NA
     
-      # compile list of how many ammonium values got set to NA with filtering
+    # compile list of how many ammonium values got set to NA with filtering
     if (any(combinedDF$ammoniumNQF %in% dropAmmoniumFlags)) {
       num3 <-
         length(combinedDF$kclAmmoniumNConc[combinedDF$ammoniumNQF %in% dropAmmoniumFlags])
@@ -253,49 +273,18 @@ def.calc.ntrans <- function(kclInt,
     } 
   }
   
-  if(!missing(dropNitrateFlags)) {
-      combinedDF$kclNitrateNitriteNConc[combinedDF$nitrateNitriteNQF %in% dropNitrateFlags] <- NA
-    
-    # compile list of how many nitrate + nitrite values got set to NA with filtering
-    if (any(combinedDF$nitrateNitriteNQF %in% dropNitrateFlags)) {
-      num4 <-
-        length(combinedDF$kclNitrateNitriteNConc[combinedDF$nitrateNitriteNQF %in% dropNitrateFlags])
-      warning4 <-
-        paste(
-          'Note:',
-          num4,
-          'records had nitrate + nitrite concentrations set to NA due to the nitrateNitriteNQF value',
-          sep = " "
-        )
-      print(warning4)
-    } 
-  } 
-  
-  # Export list of samples excluded due to flags
-  if(!missing(dropAmmoniumFlags) | !missing(dropNitrateFlags)){
-  combinedDF_flag_dropped <- combinedDF %>% 
-    filter(ammoniumNQF %in% dropAmmoniumFlags |
-             nitrateNitriteNQF %in% dropNitrateFlags) %>%
-  select(sampleID, kclSampleID, ammoniumNQF, nitrateNitriteNQF)
-  }
-  
-  # add blank info & values, calculate blank-corrected conc, add mass and soil moisture, then normal per gram
-  combinedDF_extras <- suppressWarnings(
+  # Add blank info & values, calculate blank-corrected conc including noXCorrection if relevant ----
+  combinedDF_2 <- suppressWarnings(
     suppressMessages(
       combinedDF %>%
-        mutate(
-          kclReferenceID = toupper(kclReferenceID),
-          incubationPairID = ifelse(is.na(sampleID), NA, substr(sampleID, 1, nchar(sampleID) - 9))
-        ) %>%
+        mutate(kclReferenceID = toupper(kclReferenceID)) %>%
         left_join(
           select(
             kclIntBlank,
             kclReferenceID,
             kclBlank1ID,
             kclBlank2ID,
-            kclBlank3ID
-          ),
-          by = "kclReferenceID"
+            kclBlank3ID), by = "kclReferenceID"
         ) %>%
         mutate(
           blank1NH4 = as.numeric(kclAmmoniumNConc[match(kclBlank1ID, kclSampleID)]),
@@ -305,34 +294,78 @@ def.calc.ntrans <- function(kclInt,
           blank2NO3 = as.numeric(kclNitrateNitriteNConc[match(kclBlank2ID, kclSampleID)]),
           blank3NO3 = as.numeric(kclNitrateNitriteNConc[match(kclBlank3ID, kclSampleID)]),
           blankNH4mean = rowMeans(data.frame(blank1NH4, blank2NH4, blank3NH4), na.rm = TRUE),
-          blankNO3mean = rowMeans(data.frame(blank1NO3, blank2NO3, blank3NO3), na.rm = TRUE),
-          kclAmmoniumNBlankCor = ifelse(
-            as.numeric(kclAmmoniumNConc) - blankNH4mean < 0,
-            0,
-            as.numeric(kclAmmoniumNConc) - blankNH4mean
-          ),
-          kclNitrateNitriteNBlankCor = ifelse(
-            as.numeric(kclNitrateNitriteNConc) - blankNO3mean < 0,
-            0,
-            as.numeric(kclNitrateNitriteNConc) - blankNO3mean
-          )
-        ) %>%
-        left_join(
-          select(soilMoist, sampleID, soilMoisture, dryMassFraction),
-          by = "sampleID"
-        ) %>%
-        mutate(
-          soilDryMass = soilFreshMass * dryMassFraction,
-          soilAmmoniumNugPerGram = kclAmmoniumNBlankCor * (kclVolume / 1000) / soilDryMass * 1000,
-          soilNitrateNitriteNugPerGram = kclNitrateNitriteNBlankCor * (kclVolume / 1000) / soilDryMass * 1000,
-          # the way this var is calculated, if either NH4 or NO3 is NA, the value is NA
-          soilInorganicNugPerGram = soilAmmoniumNugPerGram + soilNitrateNitriteNugPerGram
+          blankNO3mean = rowMeans(data.frame(blank1NO3, blank2NO3, blank3NO3), na.rm = TRUE), 
+          kclAmmoniumNBlankCor = kclAmmoniumNConc - blankNH4mean))) # include NH4 up here since it's not linked to noxCorrection
+      
+      if(noxCorrection == T) {
+        combinedDF_2 <- combinedDF_2 %>%
+          mutate(kclNitrateNitriteNBlankCor = ifelse(collectDate < "2022-01-01", 
+                                                     (kclNitrateNitriteNConc - blankNO3mean) + 0.77*blankNO3mean, # -0.77 is the regression slope of the 0.01 quantile for 2021 and earlier data
+                                                     kclNitrateNitriteNConc - blankNO3mean), 
+                 noxCorrection = ifelse(collectDate < "2022-01-01", "implemented", "not applicable"))
+      }
+      
+      if(noxCorrection == F) {
+        combinedDF_2 <- combinedDF_2 %>%
+          mutate(kclNitrateNitriteNBlankCor = kclNitrateNitriteNConc - blankNO3mean,
+                 noxCorrection = ifelse(collectDate < "2022-01-01", "not implemented", "not applicable"))
+      }
+ 
+    # Set concentration data to NA based on nitrate quality flags (optional) ----
+    # more complex since it does retain values that blank-correct >= -0.02 after noxCorrection
+    if(!missing(dropNitrateFlags)) {
+        combinedDF_2 <- combinedDF_2 %>%
+        mutate(kclNitrateNitriteNConc = ifelse(nitrateNitriteNQF == "blanks exceed sample value" & kclNitrateNitriteNBlankCor >= -0.02, 
+                                               kclNitrateNitriteNConc, ifelse(nitrateNitriteNQF %in% dropNitrateFlags, 
+                                                                              NA, kclNitrateNitriteNConc)), 
+               nitrateDroppedQF = ifelse(nitrateNitriteNQF == "blanks exceed sample value" & kclNitrateNitriteNBlankCor >= -0.02, 
+                                         "no", ifelse(nitrateNitriteNQF %in% dropNitrateFlags, "yes", "no")), 
+               nitrateDroppedQF = ifelse(is.na(nitrateDroppedQF), "no", nitrateDroppedQF),
+               kclNitrateNitriteNBlankCor = ifelse(is.na(kclNitrateNitriteNConc), NA, kclNitrateNitriteNBlankCor))
+        }           
+                                               
+
+    # compile list of how many nitrate + nitrite values got set to NA with filtering
+    if (sum(combinedDF_2$nitrateDroppedQF == "yes") > 0) {
+      num4 <- sum(combinedDF_2$nitrateDroppedQF == "yes")
+      warning4 <-
+        paste(
+          'Note:',
+          num4,
+          'records had nitrate + nitrite concentrations set to NA due to the nitrateNitriteNQF value',
+          sep = " "
         )
-    )
-  )
+      print(warning4)
+    } 
+    } 
   
-  # count how many samples are missing moisture values
-  samples <- combinedDF_extras[!grepl("BREF", combinedDF_extras$kclSampleID),]
+  # Export list of samples excluded due to ammonium and nitrate QF values
+  if(!missing(dropAmmoniumFlags) | !missing(dropNitrateFlags)){
+    combinedDF_flag_dropped <- combinedDF_2 %>% 
+      filter(ammoniumNQF %in% dropAmmoniumFlags |
+               nitrateDroppedQF == "yes") %>%
+      select(sampleID, kclSampleID, ammoniumNQF, nitrateNitriteNQF)
+  }
+  
+  # Set remaining negatives to 0, add mass and soil moisture, then normalize per gram dry soil ----
+    combinedDF_3 <- combinedDF_2 %>%
+    mutate(kclAmmoniumNBlankCor = ifelse(kclAmmoniumNBlankCor < 0, 0, kclAmmoniumNBlankCor),
+           kclNitrateNitriteNBlankCor = ifelse(kclNitrateNitriteNBlankCor < 0, 0, kclNitrateNitriteNBlankCor), 
+           noxCorrection = ifelse(is.na(kclNitrateNitriteNBlankCor), NA, noxCorrection)) %>%
+  left_join(
+    select(soilMoist, sampleID, soilMoisture, dryMassFraction),
+    by = "sampleID"
+  ) %>%
+    mutate(
+      soilDryMass = soilFreshMass * dryMassFraction,
+      soilAmmoniumNugPerGram = kclAmmoniumNBlankCor * (kclVolume / 1000) / soilDryMass * 1000,
+      soilNitrateNitriteNugPerGram = kclNitrateNitriteNBlankCor * (kclVolume / 1000) / soilDryMass * 1000,
+      # the way this var is calculated, if either NH4 or NO3 is NA, the value is NA
+      soilInorganicNugPerGram = soilAmmoniumNugPerGram + soilNitrateNitriteNugPerGram
+    )
+  
+  # Produce a table for missing moisture values ----
+  samples <- combinedDF_3[!grepl("BREF", combinedDF_3$kclSampleID),]
   if (any(is.na(samples$soilMoisture))) {
     num5 <-
       sum(is.na(samples$soilMoisture))
@@ -351,8 +384,9 @@ def.calc.ntrans <- function(kclInt,
       select(sampleID, kclSampleID, soilFreshMass, soilMoisture, dryMassFraction, soilDryMass)
   }
   
-  # create wide (cast) version of the df in order to calculate net rates with incubationPairID and nTransBoutType
-  combinedDFforCast <- combinedDF_extras %>%
+  
+  # Create wide (cast) version of the df in order to calculate net rates with incubationPairID and nTransBoutType ----
+  combinedDFforCast <- combinedDF_3 %>%
     filter(!sampleID == "")
   
   cast1 <-
@@ -368,7 +402,7 @@ def.calc.ntrans <- function(kclInt,
       na.rm = T
     )
   
-  # calculate net rates
+  # Calculate net rates ----
   cast1 <- cast1 %>%
     mutate(
       netInorganicNugPerGram = soilInorganicNugPerGram_tFinal - soilInorganicNugPerGram_tInitial,
@@ -377,9 +411,9 @@ def.calc.ntrans <- function(kclInt,
       netNitugPerGramPerDay = netNitrateNitriteNugPerGram / incubationLength_tFinal
     )
   
-  # attach net rates onto combined df
-  combinedDF_extras <- suppressWarnings(suppressMessages(
-    combinedDF_extras %>%
+  # Attach net rates onto combined df ----
+  combinedDF_3 <- suppressWarnings(suppressMessages(
+    combinedDF_3 %>%
       left_join(
         select(
           cast1,
@@ -394,16 +428,16 @@ def.calc.ntrans <- function(kclInt,
         netNitugPerGramPerDay = ifelse(nTransBoutType == "tInitial", NA, netNitugPerGramPerDay)
       )
   )) %>%
-    select(-c(ammoniumNRepNum, nitrateNitriteNRepNum))
+    select(-c(ammoniumNRepNum, nitrateNitriteNRepNum, nitrateDroppedQF))
   
-  # collapse concentrations and rates onto one line for the incubation pair, samples only
-  combinedDF_collapse <- combinedDF_extras %>%
+  # Collapse concentrations and rates onto one line for the incubation pair, samples only ----
+  combinedDF_collapse <- combinedDF_3 %>%
     mutate(
-      soilAmmoniumNugPerGram = ifelse(nTransBoutType == "tFinal", NA, soilAmmoniumNugPerGram),
+      soilAmmoniumNugPerGram = ifelse(nTransBoutType == "tFinal", NA, soilAmmoniumNugPerGram), # get rid of extractable N data for t-final
       soilNitrateNitriteNugPerGram = ifelse(nTransBoutType == "tFinal", NA, soilNitrateNitriteNugPerGram),
       soilInorganicNugPerGram = ifelse(nTransBoutType == "tFinal", NA, soilInorganicNugPerGram)
     ) %>%
-    filter(!sampleID == "") %>%
+    filter(!sampleID == "") %>% # get rid of blanks
     select(
       incubationPairID,
       soilAmmoniumNugPerGram,
@@ -419,22 +453,23 @@ def.calc.ntrans <- function(kclInt,
       first(.)
     }))
   
-  # make nice summary table, samples only and key variables
-  combinedDF_clean <- combinedDF_extras %>%
+  # Make nice summary table, samples only and key variables ----
+  combinedDF_clean <- combinedDF_3 %>%
     filter(nTransBoutType == "tInitial") %>%
     select(sampleID, collectDate, incubationPairID) %>%
     left_join(combinedDF_collapse, by = "incubationPairID")
   
+  # Final data cleaning and preparation for export list ----
   # set NaN to NA
-  combinedDF_extras[is.na(combinedDF_extras)] <- NA
+  combinedDF_3[is.na(combinedDF_3)] <- NA
   combinedDF_clean[is.na(combinedDF_clean)] <- NA
   
   # Round all numeric variables to 3 digits
-  combinedDF_extras <- mutate_if(combinedDF_extras, is.numeric, round, digits = 3)
+  combinedDF_3 <- mutate_if(combinedDF_3, is.numeric, round, digits = 3)
   combinedDF_clean <- mutate_if(combinedDF_clean, is.numeric, round, digits = 3)
   
   output.list <- list(
-    all_data = combinedDF_extras,
+    all_data = combinedDF_3,
     data_summary = combinedDF_clean
   )
   

--- a/neonNTrans/R/def.calc.ntrans.R
+++ b/neonNTrans/R/def.calc.ntrans.R
@@ -448,7 +448,7 @@ def.calc.ntrans <- function(kclInt,
   )) %>%
     select(-c(ammoniumNRepNum, nitrateNitriteNRepNum))
            
-  if("nitrateDropped" %in% colnames(combinedDF_3)) {
+  if("nitrateDroppedQF" %in% colnames(combinedDF_3)) {
     combinedDF_3 <- select(combinedDF_3, -nitrateDroppedQF)
   }
   

--- a/neonNTrans/R/def.calc.ntrans.R
+++ b/neonNTrans/R/def.calc.ntrans.R
@@ -363,7 +363,11 @@ def.calc.ntrans <- function(kclInt,
   
   if(!exists("combinedDF_NH4QF_dropped") & exists("combinedDF_NO3QF_dropped")){
     combinedDF_flag_dropped <- combinedDF_NO3QF_dropped
-    }
+  }
+  
+  if(nrow(combinedDF_flag_dropped) == 0){
+    rm(combinedDF_flag_dropped)
+  }
   
   # Set remaining negatives to 0, add mass and soil moisture, then normalize per gram dry soil ----
     combinedDF_3 <- combinedDF_2 %>%

--- a/neonNTrans/R/def.calc.ntrans.R
+++ b/neonNTrans/R/def.calc.ntrans.R
@@ -337,8 +337,7 @@ def.calc.ntrans <- function(kclInt,
         )
       print(warning4)
     } 
-    } 
-  
+
   # Export list of samples excluded due to ammonium and nitrate QF values
   if(!missing(dropAmmoniumFlags) | !missing(dropNitrateFlags)){
     combinedDF_flag_dropped <- combinedDF_2 %>% 

--- a/neonNTrans/README.Rmd
+++ b/neonNTrans/README.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "NEON Nitrogen Transformations"
+title: "neonNTrans"
 output: github_document
 ---
 
@@ -19,7 +19,7 @@ This package is for calculating soil extractable inorganic nitrogen (N) concentr
 
 <!-- ****** Usage ****** -->
 ## Usage
-The single function contained in this package, def.calc.ntrans, has the following purpose: (1) join variables across tables (2) calculate blank-corrected inorganic N concentrations in KCl extracts (3) convert from N concentrations in extracts (mg N/L) to soil extractable N concentrations (ug N/g dry soil), and (4) calculate net N mineralization and nitrification rates using intital and incubated core pairs. See the function help file for additional details. The general flow of using this package is:
+The single function contained in this package, def.calc.ntrans, has the following purpose: (1) join variables across tables (2) calculate blank-corrected inorganic N concentrations in KCl extracts, excluding any data with flags specified by the user (3) convert from N concentrations in extracts (mg N/L) to soil extractable N concentrations (ug N/g dry soil), and (4) calculate net N mineralization and nitrification rates using initital and incubated core pairs. See the function help file for additional details. The general flow of using this package is:
 
 1. Download data for NEON.DP1.10086, Soil physical and chemical properties, periodic.
 2. _Recommended Workflow_ Use functions from the neonUtilities package (on CRAN) to download files and/or read files directly into R. See neonUtilities package documentation for more details.
@@ -36,29 +36,40 @@ The single function contained in this package, def.calc.ntrans, has the followin
 ```
 5. Run the function with data loaded to R using the loadByProduct() example above, with option to specify flagged data to be excluded.
 ```
-out <- def.calc.ntrans(kclInt = soilData$ntr_internalLab, kclIntBlank = soilData$ntr_internalLabBlanks, kclExt = soilData$ntr_externalLab, soilMoist = soilData$sls_soilMoisture, dropAmmoniumFlags = "blanks exceed sample value", dropNitrateFlags = "blanks exceed sample value" )
+out <- def.calc.ntrans(kclInt = soilData$ntr_internalLab, kclIntBlank = soilData$ntr_internalLabBlanks, kclExt = soilData$ntr_externalLab, soilMoist = soilData$sls_soilMoisture, dropConditions = c("extract stored at incorrect temperature", "soil stored at incorrect temperature", "mass uncertain", "volume uncertain"))
 ```
-6. Alternatively, run the function with files for each of the four required input tables loaded manually, with option to specify conditions where data should be excluded.
+6. Alternatively, run the function with files for each of the four required input tables loaded manually, with option to turn off the default 'noxCorrection' that accounts for nitrite contamination in KCl batches used prior to 2022 and instead drop samples with high nitrite in blanks. 
+
 ```
 df1 <- "path/to/data/ntr_internalLab"
 df2 <- "path/to/data/ntr_internalLabBlanks"
 df3 <- "path/to/data/ntr_ntr_externalLab"
 df4 <- "path/to/data/sls_soilMoisture"
-out <- def.calc.ntrans(kclInt = df1, kclIntBlank = df2, kclExt = df3, soilMoist = df4, dropConditions = c("deprecatedMethod", "other")) 
+out <- def.calc.ntrans(kclInt = df1, kclIntBlank = df2, kclExt = df3, soilMoist = df4, noxCorrection = F, dropNitrateFlags = "blanks exceed sample value") 
 ```
 Returns a list of dataframes, at least 2 are always included and up to 5 may be returned depending on specified function parameters. data_summary will be most useful to end users as it succinctly provides inorganic N concentrations in ug N per g dry soil plus net N transformation rates in ug N per g per day for incubated samples if data from both initial and final cores are available. all_data is provided so that end users can see all of the calculations that went in to the final estimates. The other data frames are summaries of which records were excluded due to conditions, flags, or missing soil moisture values. Note that the function will not run if inorganic N concentrations from KCl extractions are not yet available from external lab analyses.
 
 <!-- ****** Calculation Summary ****** -->
 ## Calculation Summary
-The first step in converting inorganic N concentrations in KCl extracts to soil extractable inorganic N is to  blank-correct the concentration values (mg/L) for each sample. This is necessary because blanks can contain substantial ammounts of ammonium and nitrate, and this contaminant N must be accounted for. The def.calc.ntrans function thus estimates mean N concentration in the set of blanks associated with each batch of samples (typically, n = 3), then subtracts the mean blank value from measured ammonium and nitrate+nitrite N concentrations. When this results in a negative number, the sample concentration is set to 0. See function help for more discussion of this topic and a suggestion for dealing with highly negative sample values.
+The first step in converting inorganic N concentrations in KCl extracts to soil extractable inorganic N is to  blank-correct the concentration values (mg/L) for each sample. This is necessary because blanks can contain notable levels of ammonium and nitrate, and this must be accounted for. The def.calc.ntrans function thus estimates mean N concentration in the set of blanks associated with each batch of samples (typically, n = 3), then subtracts the mean blank value from measured ammonium and nitrate+nitrite N concentrations. 
 
-Next, blank-corrected concentrations are converted from milligrams N per liter to micrograms N per gram by dividing by the mass of dry soil extracted and multiplying by extraction volume. To calculate the mass of dry soil extracted, the def.calc.ntrans function multiplies the mass of field-moist soil extracted by the dry mass fraction provided for each sample in the soil moisture table.
+Sometimes this can result in a negative number, and the function sets all negative concentrations to 0. For subtle negatives near the method detection limit (0.01 - 0.02 mg/L), this substitution is robust. Yet prior to 2022, data from some sites showed strongly negative blank-corrected nitrate+nitrite N concentrations. This was caused by inadvertently using batches of KCl with high nitrite contamination, since nitrite is chemodenitrified, or abiotically converted to nitrogen gas and lost, in the presence of acidic soil but not in blanks (Homyak et al. 2015). To account for this, the function default it to correct any pre-2022 data using a quantile regression, essentially 'adding back' the lost nitrite and thus removing apparent negatives, as described by Weintraub-Leff at al. (2023). If users do not wish to apply this correction, they can turn it off and allow those strongly negative concentrations to be set to 0 instead or be excluded from further calculations. See function help for more discussion of the parameters that enable these choices.
 
-Lastly, if data are available for both an initial and final core in the pair, net N mineralization is calculated as the difference in final minus initial inorganic N (ammonium plus nitrate+nitrite N), divided by the incubation length. Net nitrification is calculated as the difference between final and initial nitrate+nitrite N, divided by the incubation length.
+The next step is to convert blank-corrected concentrations from milligrams N per liter to micrograms N per gram by dividing by the mass of dry soil extracted and multiplying by extraction volume. To calculate the mass of dry soil extracted, the def.calc.ntrans function multiplies the mass of field-moist soil extracted by the dry mass fraction provided for each sample in the soil moisture table.
+
+Lastly, if data are available for both an initial and final core in the pair, net N mineralization is calculated as the difference in final minus initial inorganic N (ammonium plus nitrate+nitrite N), divided by the incubation length. Net nitrification is calculated as the difference between final and initial nitrate+nitrite N, divided by the incubation length. Both rates can be either positive or negative numbers.
 
 For a more detailed breakdown of these calculations and a full list of all variables generated by the def.calc.ntrans function, see the NEON Data Product User Guide for Soil inorganic nitrogen pools and transformations (NEON.DP1.10086), available at the NEON Data Portal in the Resources > Document Library section or the data product landing page: https://data.neonscience.org/data-products/DP1.10086.001.
 
 Note that the def.calc.ntrans function provides a summary of how many records are missing soil concentration estimates due to lack of dry mass fraction data in the soil moisture table. Moreover, when users decide to drop data based on specific sample condition values or data quality flags (see function help file for details), the function also provides a summary of the number of records affected.
+
+<!-- ****** References ****** -->
+## References
+
+Homyak, P.M., Vasquez, K.T., Sickman, J.O., Parker, D.R. and Schimel, J.P. (2015). Improving Nitrite Analysis in Soils: Drawbacks of the Conventional 2 M KCl Extraction. Soil Science Society of America Journal, 79: 1237‐1242. doi:10.2136/sssaj2015.02.0061n
+
+Weintraub-Leff, S.R., Hall, S.J., Craig, M.E., Sihi, D., Wang, Z. and Hart, S.C. (2023). Standardized data to improve understanding and modeling of soil nitrogen at continental scale. Earth's Future, 11, e2022EF003224. doi.org/10.1029/2022EF003224
+
 
 <!-- ****** Acknowledgements ****** -->
 ## Credits & Acknowledgements

--- a/neonNTrans/man/def.calc.ntrans.Rd
+++ b/neonNTrans/man/def.calc.ntrans.Rd
@@ -126,7 +126,9 @@ dropNitrateFlags = "blanks exceed sample value"
 }
 \references{
 License: GNU AFFERO GENERAL PUBLIC LICENSE Version 3, 19 November 2007
+
 Homyak, P.M., Vasquez, K.T., Sickman, J.O., Parker, D.R. and Schimel, J.P. (2015). Improving Nitrite Analysis in Soils: Drawbacks of the Conventional 2 M KCl Extraction. Soil Science Society of America Journal, 79: 1237‐1242. doi:10.2136/sssaj2015.02.0061n
+
 Weintraub-Leff, S.R., Hall, S.J., Craig, M.E., Sihi, D., Wang, Z. and Hart, S.C. (2023). Standardized data to improve understanding and modeling of soil nitrogen at continental scale. Earth's Future, 11, e2022EF003224. doi.org/10.1029/2022EF003224
 }
 \seealso{

--- a/neonNTrans/man/def.calc.ntrans.Rd
+++ b/neonNTrans/man/def.calc.ntrans.Rd
@@ -9,6 +9,7 @@ def.calc.ntrans(
   kclIntBlank,
   kclExt,
   soilMoist,
+  noxCorrection = T,
   dropConditions,
   dropAmmoniumFlags,
   dropNitrateFlags
@@ -22,15 +23,19 @@ extractions. Data product table name is ntr_internalLab}
 extraction samples to procedural blanks. Data product table name is
 ntr_internalLabBlanks}
 
-\item{kclExt}{A data frame containing inorganic N concentrations measured in
+\item{kclExt}{A data frame containing inorganic N concentrations measured in sample
 KCl extractions and blanks. Data product table name is ntr_externalLab}
 
 \item{soilMoist}{A data frame containing soil moisture values. Data product
 table name is sls_soilMoisture}
 
+\item{noxCorrection}{A parameter that specifies whether the quantile regression
+approach outlined in Weintraub-Leff et al (2023) should be used to correct for 
+contaminant nitrite in 2021 and earlier data, defaults to T}
+
 \item{dropConditions}{An optional list of sampleCondition or dataQF values for which to exclude
-ammonium and nitrate N concentration measurements (set them to NA). See categorical codes file 
-and data product user guide for more on these fields.}
+ammonium and nitrate + nitrite N concentration measurements (set them to NA). 
+See categorical codes file and data product user guide for more on these fields.}
 
 \item{dropAmmoniumFlags}{An optional list of ammoniumNQF values for which to exclude
 ammonium N concentration measurements (set them to NA). See categorical codes file 
@@ -38,7 +43,10 @@ and data product user guide for more on these fields.}
 
 \item{dropNitrateFlags}{An optional list of nitrateNitriteNQF values for which to exclude
 nitrate+nitrite N concentration measurements (set them to NA). See categorical codes file 
-and data product user guide for more on these fields.}
+and data product user guide for more on these fields. If 'blanks exceed sample value'
+is selected along with the default noxCorrection = T, values are only dropped if
+they still blank-correct negative after the correction is applied (relevant 
+to pre-2022 data).}
 }
 \value{
 A list that contains at least 2 data frames, and up to 5 depending on specified parameters. 
@@ -47,10 +55,10 @@ plus blank-corrected concentrations normalized by soil mass as well as net rates
 incubated samples. data_summary is a cleaned-up version of this information showing only
 calculated variables and excluding lab metadata. Users will likely wish to use this table for downstream
 analyses and can join on sampleID to link with other NEON soil measurements. dropped_condition is 
-a dataframe that shows which samples had values set to NA due to dropCondition inputs (if applicable). dropped_flags
-is a dataframe that shows which samples had values set to NA due to dropAmmoniumFlags and/or
-dropNitrateFlags inputs (if applicable). dropped_moisture is a dataframe that shows which samples are
-missing soil moisture, thus precluding downstream calculations.
+a dataframe that shows which samples had values set to NA due to dropCondition inputs (if applicable). 
+dropped_flags is a dataframe that shows which samples had values set to NA due to dropAmmoniumFlags 
+and/or dropNitrateFlags inputs (if applicable). dropped_moisture is a dataframe that shows which samples 
+are missing soil moisture (if), thus precluding downstream calculations.
 }
 \description{
 Calculate soil extractable inorganic nitrogen concentrations and
@@ -60,17 +68,25 @@ Function requires several data product tables as inputs in order to complete cal
 }
 \details{
 The function calculates blank-corrected concentration data using the mean of all blanks
-extracted with a batch of samples, then normalizes these per gram dry soil (and per day for rates).
-Any negative blank-corrected KCl extraction data are set to 0 before proceeding with 
-further transformations. This is robust for slightly negative values near method detection limits (0.01-0.02). However, 
-highly negative values (< -0.02) may indicate an issue. Extensive troubleshooting by NEON suggests this was prevalent 
-in samples collected prior to 2020 due to high nitrite in the KCl powder used for extractions. This nitrite was 
-chemodenitrified (removed as a gas) under the acidic conditions of samples but not blanks, e.g., the very 
-negative values are most often a contamination artifact. Instead of setting these highly negative values to 0, we recommend 
-excluding them altogether, since there may have been N in the sample but it was not detectable given method artifacts.
-Values with blank-corrected values < -0.02 are flagged by NEON, thus users can easily exclude them using the following arguments
-in the function: dropAmmoniumFlags = "blanks exceed sample value", dropNitrateFlags = "blanks exceed sample value". 
-If these arguments are not used, all negative values will be converted to 0 and included in the analyses.
+extracted with a batch of samples, then normalizes these per gram dry soil (and per day for net rates). 
+
+Data from certain sites collected prior to 2022 exhibit frequent blank-corrected nitrate + nitrite 
+concentrations significantly negative beyond background noise (< -0.02). This was caused by inadvertently 
+using batches of potassium chloride (KCl) for soil extractions with high nitrite contamination. Nitrite is 
+chemodenitrified, or abiotically converted to nitrogen gas and lost, in the presence of acidic soil 
+but not in blanks (Homyak et al. 2015), which causes this artifact. It is possible to correct the affected 
+data using a quantile regression, essentially 'adding back' the lost nitrite and removing apparent 
+negatives (Weintraub-Leff at al. 2023). This correction is applied by the function to all data collected 
+in 2021 and earlier, unless users select noxCorrection = F. Starting with the 2022 sampling season and 
+onward, all batches of KCl are purity tested before use, greatly reducing (although not eliminating) 
+the occurrence of blank-corrected sample concentration values < -0.02. 
+
+After applying the noxCorrection (for pre-2022 data), any remaining negative 
+blank-corrected concentration values are set to 0 by the function before proceeding with 
+further data transformations. Concentration values that blank-correct to < -0.02 are flagged by NEON
+in the ntr_externalLab table, thus if users would rather exclude these data points instead of using
+the noxCorrection and/or assigning them to zero, they should specify function parameters 
+dropAmmoniumFlags or dropNitrateFlags = "blanks exceed sample value".
 }
 \examples{
 \dontrun{
@@ -87,8 +103,8 @@ kclInt = soilData$ntr_internalLab,
 kclIntBlank = soilData$ntr_internalLabBlanks, 
 kclExt = soilData$ntr_externalLab, 
 soilMoist = soilData$sls_soilMoisture, 
-dropAmmoniumFlags = "blanks exceed sample value", 
-dropNitrateFlags = "blanks exceed sample value" 
+dropConditions = c("extract stored at incorrect temperature", "soil stored at incorrect temperature", 
+"mass uncertain", "volume uncertain") 
 )
 
 # If data are downloaded to a computer, then need to be loaded manually
@@ -103,18 +119,21 @@ kclInt = df1,
 kclIntBlank = df2, 
 kclExt =df3, 
 soilMoist = df4,
-dropConditions = c("deprecatedMethod", "other"), 
+noxCorrection = F, 
+dropNitrateFlags = "blanks exceed sample value" 
 )
 }
 }
 \references{
 License: GNU AFFERO GENERAL PUBLIC LICENSE Version 3, 19 November 2007
+Homyak, P.M., Vasquez, K.T., Sickman, J.O., Parker, D.R. and Schimel, J.P. (2015). Improving Nitrite Analysis in Soils: Drawbacks of the Conventional 2 M KCl Extraction. Soil Science Society of America Journal, 79: 1237‐1242. doi:10.2136/sssaj2015.02.0061n
+Weintraub-Leff, S.R., Hall, S.J., Craig, M.E., Sihi, D., Wang, Z. and Hart, S.C. (2023). Standardized data to improve understanding and modeling of soil nitrogen at continental scale. Earth's Future, 11, e2022EF003224. doi.org/10.1029/2022EF003224
 }
 \seealso{
 Currently none
 }
 \author{
-Samantha Weintraub \email{sweintraub@battelleecology.org}
+Samantha Weintraub-Leff \email{sweintraub@battelleecology.org}
 }
 \keyword{mineralization,}
 \keyword{nitrification}


### PR DESCRIPTION
As discussed in RITM0055571 and approved by the OS-IPT, I have added an **noxCorrection** parameter to the _def.calc.ntrans_ function so that the quantile regression approach we developed in [this paper](https://agupubs.onlinelibrary.wiley.com/doi/full/10.1029/2022EF003224) can be applied to 2021 and earlier data using the function. The parameter default is set to T as advised by the OS-IPT, so users need to opt out in order to not correct the pre-2022 data. There is also a new field in the all_data output table called noxCorrection that records if the correction was implemented, not implemented, or not applicable (2022 and later data). 

There was a bit of complexity in thinking about how this parameter should interact with the 'drop flags' call for nitrate, I think I've got it working properly but an independent review would be helpful. I have a testing script located here that could be helpful for this purpose: GitHub/definitional-data/wildWestScripts/SWeintraub/neonNTrans_testing.R

I think that perhaps @carenscott or @cklunch could be good reviewers for this PR? I am also happy to rope in someone else from the DP team, just let me know. Thank you. 